### PR TITLE
merge : RedisCacheManger구현 및 토큰 검증 User 조회 캐싱 적용

### DIFF
--- a/mything/build.gradle
+++ b/mything/build.gradle
@@ -49,7 +49,11 @@ dependencies {
 	//redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-cache'
-	
+
+	//Java 8 date/time type java.time.LocalDateTime not supported by default 직렬화 역직렬화 문제 해결
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+	implementation 'com.fasterxml.jackson.core:jackson-databind'
+
 	//security
 //	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/mything/src/main/java/com/project/mything/MythingApplication.java
+++ b/mything/src/main/java/com/project/mything/MythingApplication.java
@@ -2,10 +2,12 @@ package com.project.mything;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableCaching
 public class MythingApplication {
 
 	public static void main(String[] args) {

--- a/mything/src/main/java/com/project/mything/auth/service/AuthService.java
+++ b/mything/src/main/java/com/project/mything/auth/service/AuthService.java
@@ -2,6 +2,7 @@ package com.project.mything.auth.service;
 
 import com.project.mything.auth.dto.AuthDto;
 import com.project.mything.auth.mapper.AuthMapper;
+import com.project.mything.redis.config.RedisCacheKeys;
 import com.project.mything.redis.repository.RedisRepository;
 import com.project.mything.exception.BusinessLogicException;
 import com.project.mything.exception.ErrorCode;
@@ -12,6 +13,7 @@ import com.project.mything.user.entity.UserRole;
 import com.project.mything.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -69,6 +71,7 @@ public class AuthService {
             throw new BusinessLogicException(ErrorCode.NO_MATCH_AUTH_NUMBER);
     }
 
+    @CacheEvict(key = "#requestLogin.email", value = RedisCacheKeys.USER, cacheManager = "redisCacheManager")
     public AuthDto.ResponseLogin login(AuthDto.RequestLogin requestLogin) {
         User dbUser = userService.findUserByEmail(requestLogin.getEmail());
         passwordService.validatePassword(requestLogin.getPassword(), dbUser.getPassword());
@@ -76,7 +79,7 @@ public class AuthService {
     }
 
     public void duplicateEmail(String email) {
-        if (userService.duplicateEmail(email))
+        if (Boolean.TRUE.equals(userService.duplicateEmail(email)))
             throw new BusinessLogicException(ErrorCode.EMAIL_ALREADY_EXIST);
     }
 

--- a/mything/src/main/java/com/project/mything/friend/service/FriendService.java
+++ b/mything/src/main/java/com/project/mything/friend/service/FriendService.java
@@ -8,11 +8,13 @@ import com.project.mything.friend.entity.enums.FriendStatus;
 import com.project.mything.friend.mapper.FriendMapper;
 import com.project.mything.friend.repository.FriendRepository;
 import com.project.mything.page.ResponseMultiPageDto;
+import com.project.mything.redis.config.RedisCacheKeys;
 import com.project.mything.user.dto.UserDto;
 import com.project.mything.user.entity.User;
 import com.project.mything.user.mapper.UserMapper;
 import com.project.mything.user.service.UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -35,6 +37,7 @@ public class FriendService {
     }
 
     @Transactional(readOnly = true)
+    @Cacheable(key = "#isBirthday.booleanValue()", value = RedisCacheKeys.FRIEND_LIST,cacheManager = "redisCacheManager")
     public ResponseMultiPageDto<FriendDto.ResponseSimpleFriend> getFriendsList(UserDto.UserInfo userInfo,
                                                                                FriendStatus friendStatus,
                                                                                Boolean isBirthday) {
@@ -43,7 +46,7 @@ public class FriendService {
                         friendStatus,
                         isBirthday,
                         PageRequest.of(0, 999));
-        return new ResponseMultiPageDto<FriendDto.ResponseSimpleFriend>(friendList.getContent(), friendList);
+        return new ResponseMultiPageDto<>(friendList.getContent(), friendList);
     }
 
     public void createFriend(Long sendUserId, Long receiveUserId) {

--- a/mything/src/main/java/com/project/mything/redis/config/RedisCacheKeys.java
+++ b/mything/src/main/java/com/project/mything/redis/config/RedisCacheKeys.java
@@ -1,0 +1,6 @@
+package com.project.mything.redis.config;
+
+public class RedisCacheKeys {
+    public static final String USER = "user";
+    public static final String FRIEND_LIST = "friendList_isBirthday";
+}

--- a/mything/src/main/java/com/project/mything/redis/config/RedisConfig.java
+++ b/mything/src/main/java/com/project/mything/redis/config/RedisConfig.java
@@ -1,17 +1,21 @@
 package com.project.mything.redis.config;
 
-import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
-import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.data.redis.serializer.*;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 
 @Configuration
-@RequiredArgsConstructor
 @EnableRedisRepositories
 public class RedisConfig {
     @Value("${spring.redis.host}")
@@ -31,5 +35,27 @@ public class RedisConfig {
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setValueSerializer(new StringRedisSerializer());
         return redisTemplate;
+    }
+
+    @Bean
+    public RedisCacheManager redisCacheManager(RedisConnectionFactory redisConnectionFactory) {
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofMinutes(30))
+                .serializeKeysWith(RedisSerializationContext
+                        .SerializationPair
+                        .fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext
+                        .SerializationPair
+                        .fromSerializer(new GenericJackson2JsonRedisSerializer()));
+
+        Map<String, RedisCacheConfiguration> cacheConfiguration = new HashMap<>();
+        cacheConfiguration.put(RedisCacheKeys.USER, redisCacheConfiguration.disableCachingNullValues().entryTtl(Duration.ofMinutes(30)));
+        cacheConfiguration.put(RedisCacheKeys.FRIEND_LIST, redisCacheConfiguration.disableCachingNullValues().entryTtl(Duration.ofMinutes(60)));
+
+        return RedisCacheManager.RedisCacheManagerBuilder
+                .fromConnectionFactory(redisConnectionFactory)
+                .cacheDefaults(redisCacheConfiguration)
+                .withInitialCacheConfigurations(cacheConfiguration)
+                .build();
     }
 }

--- a/mything/src/main/java/com/project/mything/security/jwt/service/CustomDetails.java
+++ b/mything/src/main/java/com/project/mything/security/jwt/service/CustomDetails.java
@@ -1,6 +1,6 @@
 package com.project.mything.security.jwt.service;
 
-import com.project.mything.user.entity.User;
+import com.project.mything.user.dto.UserDto;
 import com.project.mything.user.entity.enums.RoleName;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -16,10 +16,10 @@ import java.util.Collection;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CustomDetails implements UserDetails {
 
-    private User user;
+    private UserDto.SecurityUserDetail userDetail;
 
-    public CustomDetails(User user) {
-        this.user = user;
+    public CustomDetails(UserDto.SecurityUserDetail userDetail) {
+        this.userDetail = userDetail;
     }
 
     @Override
@@ -31,12 +31,12 @@ public class CustomDetails implements UserDetails {
 
     @Override
     public String getPassword() {
-        return user.getPassword();
+        return userDetail.getPassword();
     }
 
     @Override
     public String getUsername() {
-        return user.getEmail();
+        return userDetail.getEmail();
     }
 
     @Override

--- a/mything/src/main/java/com/project/mything/security/jwt/service/CustomDetailsService.java
+++ b/mything/src/main/java/com/project/mything/security/jwt/service/CustomDetailsService.java
@@ -1,6 +1,6 @@
 package com.project.mything.security.jwt.service;
 
-import com.project.mything.user.entity.User;
+import com.project.mything.user.dto.UserDto;
 import com.project.mything.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,7 +18,7 @@ public class CustomDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        User user = userService.findUserByEmail(username);
-        return new CustomDetails(user);
+        UserDto.SecurityUserDetail userDetail = userService.findSecurityUserDetail(username);
+        return new CustomDetails(userDetail);
     }
 }

--- a/mything/src/main/java/com/project/mything/user/dto/UserDto.java
+++ b/mything/src/main/java/com/project/mything/user/dto/UserDto.java
@@ -1,5 +1,9 @@
 package com.project.mything.user.dto;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
 import com.querydsl.core.annotations.QueryProjection;
 import com.project.mything.image.dto.ImageDto;
 import lombok.*;
@@ -35,6 +39,8 @@ public class UserDto {
         private Long userId;
         private String name;
         private String phone;
+        @JsonSerialize(using = LocalDateSerializer.class)
+        @JsonDeserialize(using = LocalDateDeserializer.class)
         private LocalDate birthday;
         private String infoMessage;
         ImageDto.SimpleImageDto avatar;
@@ -84,5 +90,14 @@ public class UserDto {
         private String originalPassword;
         @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[~!@#$%^&*()+|=])[A-Za-z\\d~!@#$%^&*()+|=]{8,16}$", message = "영문+숫자+특수문자 8자 이상 20자 이하 입니다.")
         private String newPassword;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class SecurityUserDetail {
+        private String email;
+        private String password;
     }
 }

--- a/mything/src/main/java/com/project/mything/user/mapper/UserMapper.java
+++ b/mything/src/main/java/com/project/mything/user/mapper/UserMapper.java
@@ -18,4 +18,8 @@ public interface UserMapper {
     @Mapping(source = "user.image.id", target = "avatar.imageId")
     @Mapping(source = "user.image.remotePath", target = "avatar.remotePath")
     UserDto.ResponseDetailUser toResponseDetailUser(User user);
+
+    @Mapping(source = "user.email", target = "email")
+    @Mapping(source = "user.password", target = "password")
+    UserDto.SecurityUserDetail toSecurityUserDetail(User user);
 }

--- a/mything/src/test/java/com/project/mything/auth/integration/AuthTest.java
+++ b/mything/src/test/java/com/project/mything/auth/integration/AuthTest.java
@@ -59,6 +59,21 @@ public class AuthTest {
     }
 
     @Test
+    @DisplayName("로그인 실패 테스트")
+    public void login_fail() throws Exception {
+        //given
+        String content = objectMapper.writeValueAsString(REQUEST_LOGIN);
+        //when
+        ResultActions perform = mockMvc.perform(
+                post("/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(content)
+        );
+        //then
+        perform.andExpect(status().isConflict());
+    }
+
+    @Test
     @DisplayName("로그인 성공 테스트")
     public void login_suc() throws Exception {
         //given
@@ -77,21 +92,6 @@ public class AuthTest {
         perform.andExpect(status().isCreated())
                 .andExpect(jsonPath("userId").value(originalUser.getId()))
                 .andExpect(jsonPath("accessToken").exists());
-    }
-
-    @Test
-    @DisplayName("로그인 실패 테스트")
-    public void login_fail() throws Exception {
-        //given
-        String content = objectMapper.writeValueAsString(REQUEST_LOGIN);
-        //when
-        ResultActions perform = mockMvc.perform(
-                post("/auth/login")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(content)
-        );
-        //then
-        perform.andExpect(status().isConflict());
     }
 
     @Test


### PR DESCRIPTION
UserDto.SecurityUserDetail 클래스 생성 후 CustomDetails 클래스에서 의존하고 있던 User 클래스를 SecurityUserDetail 클래스로 변경
UserService에  findSecuritySecurityUserDetail 메서드 생성 후 캐싱 적용 -> 토큰 검증 로직에서 더 이상 DB에 접근하지 않음

**SecurityUserDetail**
  - private String email;
  - private String password;


FriendService.getFriendList() 메서드 캐싱 적용 하지만, 추후 리펙터링 필요
- 생일인 유저만 조회하도록 API 기능 분리 필요
- 캐싱 key값을 어떻게 설정할 지 계획 필요 
- 캐싱 데이터를 언제 삭제할 지 계획 필요 